### PR TITLE
Libimagtodo/more cleanup

### DIFF
--- a/libimagtodo/Cargo.toml
+++ b/libimagtodo/Cargo.toml
@@ -9,6 +9,7 @@ task-hookrs = "0.2"
 uuid = "0.2.0"
 toml = "0.1.28"
 log = "0.3.6"
+serde_json = "0.7.3"
 
 [dependencies.libimagstore]
 path = "../libimagstore"

--- a/libimagtodo/Cargo.toml
+++ b/libimagtodo/Cargo.toml
@@ -8,6 +8,7 @@ semver = "0.2"
 task-hookrs = "0.2"
 uuid = "0.2.0"
 toml = "0.1.28"
+log = "0.3.6"
 
 [dependencies.libimagstore]
 path = "../libimagstore"

--- a/libimagtodo/src/lib.rs
+++ b/libimagtodo/src/lib.rs
@@ -2,6 +2,7 @@ extern crate semver;
 extern crate uuid;
 extern crate toml;
 #[macro_use] extern crate log;
+extern crate serde_json;
 
 #[macro_use] extern crate libimagstore;
 #[macro_use] extern crate libimagerror;

--- a/libimagtodo/src/lib.rs
+++ b/libimagtodo/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate semver;
 extern crate uuid;
 extern crate toml;
+#[macro_use] extern crate log;
 
 #[macro_use] extern crate libimagstore;
 #[macro_use] extern crate libimagerror;


### PR DESCRIPTION
This moves some more code from the binary crate into the library crate.

`imag-todo` now builds for me. Not sure whether it actually works the way we intended, but I consider this PR ready and I'd like to see it merged.

I will test now (finally) and provide fixes in new PRs!
